### PR TITLE
reduce our isMusl check's scope

### DIFF
--- a/packages/fetch-engine/src/getos.ts
+++ b/packages/fetch-engine/src/getos.ts
@@ -18,10 +18,19 @@ export async function getos() {
     }
   }
 
-  const isMusl = await exists('/etc/os-release')
+  const isMusl = isAWSLambda()
 
   return {
     platform: 'linux',
     isMusl,
   }
+}
+
+// There doesn't seem to be a reliable way to
+// check if the distro supports glibc's shared
+// libraries or not.
+//
+// For now, we can add these checks as needed.
+function isAWSLambda(): boolean {
+  return !!process.env['AWS_EXECUTION_ENV']
 }


### PR DESCRIPTION
This check changes is `isMusl` logic to only pass for AWS Lambda, since it was passing for CodeSandbox, but CodeSandbox does support glibc (and our musl builds were not working)

I don't think we'll find a reliable way to test for `isMusl` so for now I'm thinking we'll just have an include list, starting with AWS Lambda.

What do you think?