### PR TITLE
Proposed fix for VSCode watch issues.

### DIFF
--- a/packages/photon/src/generation/generateClient.ts
+++ b/packages/photon/src/generation/generateClient.ts
@@ -140,7 +140,9 @@ export async function generateClient({
     const filePath = path.join(outputDir, fileName)
     // The deletion of the file is necessary, so VSCode
     // picks up the changes.
-    await fs.unlink(filePath)
+    if (fs.exists(filePath)) {
+      await fs.unlink(filePath)
+    }
     await fs.writeFile(filePath, file)
   }))
   await fs.copy(path.join(__dirname, '../../runtime'), path.join(outputDir, '/runtime'))


### PR DESCRIPTION
Seems like deleting/re-creating the file will trigger VSCode reloading all types.
`writeFile` from node uses the same file, truncates it and re-writes the contents.

I did not test this specific fix, as I don't know how to build/use photon locally with prisma dev.