### PR TITLE
Add password field to SignupUserRequest

### DIFF
--- a/examples/typescript/grpc/service.proto
+++ b/examples/typescript/grpc/service.proto
@@ -53,6 +53,7 @@ message PostRequest {
 message SignupUserRequest {
   string name = 1;
   string email = 2;
+  string password = 3;
 }
 
 message CreateDraftRequest {


### PR DESCRIPTION
Password field was missing from `service.proto` and it was not possible to signup users.