### PR TITLE
Fix export of generated exports for ES interop

### DIFF
--- a/packages/photon/src/generation/generateClient.ts
+++ b/packages/photon/src/generation/generateClient.ts
@@ -277,14 +277,13 @@ function redirectToLib(fileName: string) {
 
 function addEsInteropRequire(code: string) {
   const interopCode = `module.exports = Photon; // needed to support const Photon = require('...') in js
-module.exports.default = Photon
-Object.defineProperty(module.exports, "__esModule", { value: true });`
-  const lines = code.split('\n')
-  const exportLineIndex = lines.findIndex(line => line.startsWith('exports.default'))
-
-  lines.splice(exportLineIndex, 0, interopCode)
+Object.defineProperty(module.exports, "__esModule", { value: true });
+for (var key in exports) {
+    module.exports[key] = exports[key];
+}`;
+  const lines = code.split('\n');
   // we now need to reexpose all exports as `exports` is dangling now
   // yes we go through a lot of trouble for our users
-  lines.push(`module.exports.dmmf = exports.dmmf`)
-  return lines.join('\n')
+  lines.push(interopCode);
+  return lines.join('\n');
 }


### PR DESCRIPTION
Datamodel enums are currently being exported in the node `exports` object, yet `module.exports` is overwritten with `Photon`, causing the exports to become unreachable.

The current code re-exports `dmmf`, but not other generated objects/types. This change fixes that by ensuring all `exports` are exported in `module.exports`.

Example data model suffering from this issue:

```
model Person {
  id        String     @default(cuid()) @id @unique
  type      PersonType
}

enum PersonType {
  Adult
  Kid
  Baby
}
```

With the previous model, we get this behaviour:

```
import Photon, { PersonType } from '@generated/photon';

console.log(typeof PersonType === 'undefined'); // <— true
```

This fix ensures `PersonType` is correctly exported and usable in client code.