### PR TITLE
Update TS/graphql README example queries

### DIFF
--- a/examples/.github/readmes/_using-the-graphql-api.md
+++ b/examples/.github/readmes/_using-the-graphql-api.md
@@ -29,8 +29,10 @@ query {
 ```graphql
 mutation {
   signupUser(
-    name: "Sarah"
-    email: "sarah@prisma.io"
+    data: {
+      name: "Sarah"
+      email: "sarah@prisma.io"
+    }
   ) {
     id
   }
@@ -73,7 +75,7 @@ mutation {
     id
     title
     content
-    published 
+    published
     author {
       id
       name
@@ -107,7 +109,8 @@ mutation {
 
 ```graphql
 mutation {
-  deletePost(id: "__POST_ID__") {
+  deleteOnePost(where: {id: "__POST_ID__"})
+  {
     id
   }
 }

--- a/examples/typescript/graphql/README.md
+++ b/examples/typescript/graphql/README.md
@@ -8,13 +8,13 @@ This example shows how to implement a **GraphQL server with TypeScript** based o
 
 Clone the repository:
 
-```sh
+```
 git clone git@github.com:prisma/photonjs.git
 ```
 
 Install Node dependencies:
 
-```sh
+```
 cd photonjs/examples/typescript/graphql
 npm install
 ```
@@ -52,11 +52,12 @@ Now you can seed your database using the `seed` script from `package.json`:
 npm run seed
 ```
 
+
 ### 5. Start the GraphQL server
 
 Launch your GraphQL server with this command:
 
-```sh
+```
 npm run start
 ```
 
@@ -93,8 +94,10 @@ query {
 ```graphql
 mutation {
   signupUser(
-    name: "Sarah"
-    email: "sarah@prisma.io"
+    data: {
+      name: "Sarah"
+      email: "sarah@prisma.io"
+    }
   ) {
     id
   }
@@ -171,7 +174,8 @@ mutation {
 
 ```graphql
 mutation {
-  deletePost(id: "__POST_ID__") {
+  deleteOnePost(where: {id: "__POST_ID__"})
+  {
     id
   }
 }
@@ -181,9 +185,10 @@ mutation {
 
 </Details>
 
+
 ### 7. Changing the GraphQL schema
 
-To make changes to the GraphQL schema, you need to manipulate the `Query` and `Mutation` types that are defined in [`index.ts`](./src/index.ts).
+To make changes to the GraphQL schema, you need to manipulate the `Query` and `Mutation` types that are defined in [`index.ts`](./src/index.ts). 
 
 Note that the [`start`](./package.json#L4) script also starts a development server that automatically updates your schema every time you save a file. This way, the auto-generated [GraphQL schema](./src/schema.graphql) updates whenever you make changes in to the `Query` or `Mutation` types inside your TypeScript code.
 


### PR DESCRIPTION
Some example queries in typescript/graphql do not agree with the present API.

`signupUser` requires a `data` key wrapping the mutation values
`deletePost` is `deleteOnePost ` in the API.

This PR adjusts the README examples to match the API.