### PR TITLE
Update fetch-engine permission error message

### DIFF
--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -42,7 +42,7 @@ export async function downloadMigrationBinary(
   } catch (err) {
     if (err.code === 'EACCES') {
       warn('Please try installing Prisma CLI again with the `--unsafe-perm` option.')
-      info('Example: `npm i -g --unsafe-perm prisma`')
+      info('Example: `npm i -g --unsafe-perm prisma2`')
 
       process.exit()
     }
@@ -128,7 +128,7 @@ export async function download(prismaBinPath: string, version: string = 'latest'
   } catch (err) {
     if (err.code === 'EACCES') {
       warn('Please try installing Prisma CLI again with the `--unsafe-perm` option.')
-      info('Example: `npm i -g --unsafe-perm prisma`')
+      info('Example: `npm i -g --unsafe-perm prisma2`')
 
       process.exit()
     }


### PR DESCRIPTION
When installing on macOS 10.14.5 (Mojave) I receive a permissions error and a suggested command to correct the error.

The corrected command refers to `prisma` where it should mention `prisma2`. This PR corrects that issue.

