### PR TITLE
Update TS/graphql-auth seed to match README

### DIFF
--- a/examples/typescript/graphql-auth/prisma/seed.ts
+++ b/examples/typescript/graphql-auth/prisma/seed.ts
@@ -6,7 +6,7 @@ async function main() {
     data: {
       email: 'alice@prisma.io',
       name: 'Alice',
-      password: '$2b$10$dqyYw5XovLjpmkYNiRDEWuwKaRAvLaG45fnXE5b3KTccKZcRPka2m', // "secret42"
+      password: '$2b$10$ZjONRZAxqX2pLoPax2xdcuzABTUEsFanQI6yBYCRtzpRiU4/X1uIu', // "graphql"
       posts: {
         create: {
           title: 'Join us for Prisma Day 2019 in Berlin',


### PR DESCRIPTION
This PR updates the typescript/examples/graphql-auth `seed.ts` so user `alice@prisma.io` in the seed matches example queries in the README.