### PR TITLE
TS examples - Remove unneeded 'output' property

### DIFF
--- a/examples/typescript/graphql-auth/prisma/schema.prisma
+++ b/examples/typescript/graphql-auth/prisma/schema.prisma
@@ -10,7 +10,6 @@ generator photon {
 
 generator nexus_prisma {
   provider = "nexus-prisma"
-  output   = "node_modules/@generated/nexus-prisma"
 }
 
 model Post {

--- a/examples/typescript/graphql/prisma/schema.prisma
+++ b/examples/typescript/graphql/prisma/schema.prisma
@@ -10,7 +10,6 @@ generator photon {
 
 generator nexus_prisma {
   provider = "nexus-prisma"
-  output   = "node_modules/@generated/nexus-prisma"
 }
 
 model User {


### PR DESCRIPTION
Since prisma2 2.0.0-preview-2 `schema.prisma` `generator` key `output` 
property works as expected for provider `nexus_prisma`.

The `output` property is no longer required for `generator nexus_prisma`, in fact, the `output` 
value as it exists places the generated `nexus-prisma` package into
`./prisma/node_modules/@generated/nexus-prisma` rather than `./node_modules/@generated/nexus-prisma`

This PR corrects the 'graphql' and 'graphql-auth' TS examples to 
work as expected with release-2