### PR TITLE
GraphQL is an unlisted dependency of the graphql-apollo-server example.

### DIFF
--- a/examples/typescript/graphql-apollo-server/package.json
+++ b/examples/typescript/graphql-apollo-server/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@prisma/nexus": "^0.0.1",
     "apollo-server": "2.6.3",
+    "graphql": "^14.4.2",
     "nexus": "0.11.7"
   },
   "devDependencies": {


### PR DESCRIPTION
I was receiving `module not found: graphql` errors when running `npm start` in this example, looks like `graphql` just needed to be in the `package.json`.