### PR TITLE
graphql-auth examples - TypeError: definitions.trim is not a function

### DIFF
--- a/examples/javascript/graphql-auth/package.json
+++ b/examples/javascript/graphql-auth/package.json
@@ -14,5 +14,8 @@
   },
   "devDependencies": {
     "ts-node": "^8.3.0"
+  },
+  "resolutions": {
+    "graphql-middleware": "3.0.1"
   }
 }

--- a/examples/javascript/graphql-auth/src/index.js
+++ b/examples/javascript/graphql-auth/src/index.js
@@ -9,7 +9,10 @@ const photon = new Photon.default()
 const server = new GraphQLServer({
   typeDefs: 'src/schema.graphql',
   resolvers,
-  // middlewares: [permissions], TODO: Fix after https://github.com/maticzav/graphql-shield/issues/361
+  // TODO: requires graphql-middleware 3.0.1
+  // 3.0.2 throws TypeError: definitions.trim is not a function
+  // see https://github.com/prisma/graphql-middleware/issues/198
+  middlewares: [permissions],
   context: request => {
     return {
       ...request,

--- a/examples/typescript/graphql-auth/package.json
+++ b/examples/typescript/graphql-auth/package.json
@@ -21,5 +21,8 @@
     "ts-node": "^8.3.0",
     "ts-node-dev": "1.0.0-pre.40",
     "typescript": "3.5.2"
+  },
+  "resolutions": {
+    "graphql-middleware": "3.0.1"
   }
 }

--- a/examples/typescript/graphql-auth/src/index.ts
+++ b/examples/typescript/graphql-auth/src/index.ts
@@ -38,7 +38,10 @@ const schema = makeSchema({
 
 const server = new GraphQLServer({
   schema,
-  // middlewares: [permissions], // TODO: Fix after https://github.com/maticzav/graphql-shield/issues/361
+  // TODO: requires graphql-middleware 3.0.1
+  // 3.0.2 throws TypeError: definitions.trim is not a function
+  // see https://github.com/prisma/graphql-middleware/issues/198
+  middlewares: [permissions],
   context: request => {
     return {
       ...request,


### PR DESCRIPTION
This PR presents a work around for: `TypeError: definitions.trim is not a function`.

**_Important: this solution only works with yarn - npm does not support the resolutions key_**

As a such, it is probably not appropriate to merge this PR, but this is a viable solution for yarn users.

The problem is triggered when `graphql-sheild` is enabled and `graphql-middleware@3.0.2` is installed. See graphql-middleware [#198](https://github.com/prisma/graphql-middleware/issues/198).

GraphQL Shield can be enabled  when `package.json` `resolutions` key specifies 

```json
"resolutions": {
  "graphql-middleware": "3.0.1"
}
```
If this resolution were merged into master, the READMEs would need to be modified to specify a dependency on yarn.
