### PR TITLE
feat: windows support

### DIFF
--- a/packages/fetch-engine/src/download.ts
+++ b/packages/fetch-engine/src/download.ts
@@ -102,10 +102,11 @@ export async function download(options: DownloadOptions) {
 }
 
 function getBinaryName(binaryName, platform) {
+  const extension = platform === 'windows' ? '.exe' : ''
   if (binaryName === 'migration-engine') {
-    return 'migration-engine'
+    return 'migration-engine' + extension
   }
-  return `${binaryName}-${platform}`
+  return `${binaryName}-${platform}${extension}`
 }
 
 async function downloadBinary({

--- a/packages/fetch-engine/src/util.ts
+++ b/packages/fetch-engine/src/util.ts
@@ -53,7 +53,8 @@ function rewriteKind(kind: BinaryKind) {
 }
 
 export function getDownloadUrl(channel: string, version: string, platform: string, binaryName: BinaryKind) {
+  const extension = platform === 'windows' ? '.exe.gz' : '.gz' 
   return `https://s3-eu-west-1.amazonaws.com/prisma-native/${channel}/${version}/${platform}/${rewriteKind(
     binaryName,
-  )}.gz`
+  )}${extension}`
 }

--- a/packages/get-platform/src/getPlatform.ts
+++ b/packages/get-platform/src/getPlatform.ts
@@ -106,11 +106,15 @@ async function gracefulExec(cmd: string): Promise<string | undefined> {
 export async function getPlatform(): Promise<Platform> {
   const { platform, libssl, distro } = await getos()
 
+  debug({ platform, libssl })
+
   if (platform === 'darwin') {
     return 'darwin'
   }
 
-  debug({ platform, libssl })
+  if (platform === 'win32') {
+    return 'windows'
+  }
 
   if (platform === 'linux' && libssl) {
     if (libssl === '1.0.2') {

--- a/packages/get-platform/src/platforms.ts
+++ b/packages/get-platform/src/platforms.ts
@@ -5,3 +5,4 @@ export type Platform =
   | 'linux-glibc-libssl1.0.2'
   | 'linux-glibc-libssl1.0.2-ubuntu1604'
   | 'linux-glibc-libssl1.1.0'
+  | 'windows'

--- a/packages/photon/src/engineCommands.ts
+++ b/packages/photon/src/engineCommands.ts
@@ -8,7 +8,9 @@ import { ExternalDMMF } from './runtime/dmmf-types'
 async function getPrismaPath(): Promise<string> {
   // tslint:disable-next-line
   const dir = eval('__dirname')
-  const relative = `../query-engine-${await getPlatform()}`
+  const platform = await getPlatform()
+  const extension = (platform === 'windows') ? '.exe' : ''
+  const relative = `../query-engine-${platform}${extension}`
   return path.join(dir, relative)
 }
 
@@ -65,7 +67,7 @@ export async function getConfig(
     if (e.stdout) {
       throw new Error(chalk.redBright.bold('Get config ') + e.stdout)
     }
-    throw new Error(e)
+    throw new Error(chalk.redBright.bold('Get config ') + e)
   }
 }
 

--- a/packages/photon/src/generation/generateClient.ts
+++ b/packages/photon/src/generation/generateClient.ts
@@ -249,7 +249,8 @@ In case you want to fix this, you can provide ${chalk.greenBright(
   }
 
   for (const resolvedPlatform of builtinPlatforms) {
-    const binaryName = `query-engine-${resolvedPlatform}`
+    const extension = platform === 'windows' ? '.exe' : '' 
+    const binaryName = `query-engine-${resolvedPlatform}${extension}`
     const source = path.join(__dirname, '../../', binaryName)
     const target = path.join(outputDir, '/runtime', binaryName)
     debug(`Copying ${source} to ${target}`)


### PR DESCRIPTION
This PR adds support for using photon on Windows:

- fix download: s3 path
- fix copy/rename: binary name + extension
- fix usage: binary name + extension

We think tests are failing because `@prisma/fetch-engine` and `@prisma/get-platform` are not published yet (maybe?). Linked locally it worked.

Part of https://github.com/prisma/prisma2/issues/460
Related to https://github.com/prisma/lift/pull/125

Co-authored-by: Divyendu Singh <singh@prisma.io>

closes https://github.com/prisma/prisma2/issues/504
closes https://github.com/prisma/prisma2/issues/483
