### PR TITLE
Fix error on multiple sqlite datasources

### DIFF
--- a/packages/photon/src/generation/extractSqliteSources.ts
+++ b/packages/photon/src/generation/extractSqliteSources.ts
@@ -9,8 +9,8 @@ export interface DatasourceOverwrite {
 export function extractSqliteSources(datamodel: string, cwd: string, outputDir: string): DatasourceOverwrite[] {
   const overrides: DatasourceOverwrite[] = []
   const lines = datamodel.split('\n').filter(l => !l.trim().startsWith('//'))
-  const lineRegex = /\s*url\s+=\s*"(file:[^\/].*)"/g
-  const startRegex = /\s*datasource\s*(\w+)\s*{/g
+  const lineRegex = /\s*url\s+=\s*"(file:[^\/].*)"/
+  const startRegex = /\s*datasource\s*(\w+)\s*{/
 
   lines.forEach((line, index) => {
     const match = lineRegex.exec(line)


### PR DESCRIPTION
Fixes #265 

Because we uses the regexp more than once on different strings, it could sometime not match when it should have:

```js
const startRegex = /\s*datasource\s*(\w+)\s*{/g

startRegex.exec("datasource db {") // will match
startRegex.exec("datasource db2 {") // will return undefined
```

(See more on why it doesn't work [here](https://stackoverflow.com/questions/11477415/why-does-javascripts-regex-exec-not-always-return-the-same-value))

There is two possible solutions:
1. Recreate a `new RegExp(startRegex)` before executing it
2. Don't use the `g` flag since there will most likely only be one match per line

This PR implements the second solution 👌 