### PR TITLE
Make prisma2 an optional peer dependency

### DIFF
--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -89,5 +89,10 @@
   },
   "peerDependencies": {
     "prisma2": "*"
+  },
+  "peerDependenciesMeta": {
+    "prisma2": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
By making `prisma2` optional, it doesn't get bundled by tools like [Netlify's zip-it-and-ship-it](https://github.com/netlify/zip-it-and-ship-it), making it possible to deploy serverless lambda functions without exceeding the 50 MB file upload limit on AWS.

**Edit:** Is `prisma2` really required as a peer dependency? By removing its reference from `peerDependencies`, my bundle's size has reduced drastically:

![image](https://user-images.githubusercontent.com/14854048/69764088-729aa180-116f-11ea-87cb-37fe9197448a.png)

A viable alternative is to make `prisma2` an optional (non-peer) dependency.