### PR TITLE
Switch to ES2018

### DIFF
--- a/packages/engine-core/tsconfig.json
+++ b/packages/engine-core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["esnext"],
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "strict": false,
     "esModuleInterop": true,
     "sourceMap": true,

--- a/packages/fetch-engine/tsconfig.json
+++ b/packages/fetch-engine/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "lib": ["esnext"],
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "strict": false,
     "esModuleInterop": true,
     "sourceMap": true,

--- a/packages/get-platform/tsconfig.json
+++ b/packages/get-platform/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["esnext"],
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "strict": false,
     "esModuleInterop": true,
     "sourceMap": true,

--- a/packages/photon/fixtures/chinook/tsconfig.json
+++ b/packages/photon/fixtures/chinook/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["esnext", "esnext.asynciterable"],
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "strict": true,
     "esModuleInterop": true,
     "sourceMap": true,

--- a/packages/photon/scripts/build-runtime.js
+++ b/packages/photon/scripts/build-runtime.js
@@ -10,7 +10,7 @@ const runtimeTsConfig = {
   compilerOptions: {
     lib: ['esnext', 'esnext.asynciterable'],
     module: 'commonjs',
-    target: 'es2017',
+    target: 'es2018',
     strict: false,
     esModuleInterop: true,
     sourceMap: true,

--- a/packages/photon/src/generation/generateClient.ts
+++ b/packages/photon/src/generation/generateClient.ts
@@ -109,7 +109,7 @@ export async function buildClient({
 
   const options: CompilerOptions = {
     module: ModuleKind.CommonJS,
-    target: ScriptTarget.ES2017,
+    target: ScriptTarget.ES2018,
     lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
     declaration: true,
     strict: true,
@@ -125,7 +125,7 @@ export async function buildClient({
     if (fileName === file.fileName) {
       file.sourceFile =
         file.sourceFile ||
-        createSourceFile(fileName, file.content, ScriptTarget.ES2015, true)
+        createSourceFile(fileName, file.content, ScriptTarget.ES2018, true)
       return file.sourceFile
     }
     return (originalGetSourceFile as any).call(compilerHost, newFileName)

--- a/packages/photon/tsconfig.json
+++ b/packages/photon/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["esnext"],
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2018",
     "strict": true,
     "esModuleInterop": true,
     "sourceMap": true,


### PR DESCRIPTION
As https://nodejs.org/en/about/releases/

Node.js 8 is officially out of maintenance today.

ES2018 means Node 10 minimum https://node.green/#ES2018